### PR TITLE
wall_comment_thread add `show_reply_button`

### DIFF
--- a/objects.json
+++ b/objects.json
@@ -11536,6 +11536,10 @@
           "items": {
             "$ref": "objects.json#/definitions/wall_wall_comment"
           }
+        },
+        "show_reply_button": {
+          "type": "boolean",
+          "description": "Information whether recommended to display reply button"
         }
       },
       "required": [


### PR DESCRIPTION
https://vk.com/dev/objects/comment
> show_reply_button (boolean) – true if it is recommended to display "reply" button.


