### PR TITLE
Fix video_video_files properties

### DIFF
--- a/objects.json
+++ b/objects.json
@@ -11222,27 +11222,27 @@
           "format": "uri",
           "description": "URL of the external player"
         },
-        "mp_1080": {
+        "mp4_1080": {
           "type": "string",
           "format": "uri",
           "description": "URL of the mpeg4 file with 1080p quality"
         },
-        "mp_240": {
+        "mp4_240": {
           "type": "string",
           "format": "uri",
           "description": "URL of the mpeg4 file with 240p quality"
         },
-        "mp_360": {
+        "mp4_360": {
           "type": "string",
           "format": "uri",
           "description": "URL of the mpeg4 file with 360p quality"
         },
-        "mp_480": {
+        "mp4_480": {
           "type": "string",
           "format": "uri",
           "description": "URL of the mpeg4 file with 480p quality"
         },
-        "mp_720": {
+        "mp4_720": {
           "type": "string",
           "format": "uri",
           "description": "URL of the mpeg4 file with 720p quality"


### PR DESCRIPTION
Fix `mp_*` -> `mp4_*`

```json
"files": {
  "mp4_240": "https://cs501232....ooCUvlaXQ-Bb_7-8n9w",
  "mp4_360": "https://cs501100....ooCUvlaXQ-Bb_7-8n9w",
  "mp4_480": "https://cs500205....ooCUvlaXQ-Bb_7-8n9w",
  "mp4_720": "https://cs501136....ooCUvlaXQ-Bb_7-8n9w",
  "mp4_1080": "https://cs534231....ooCUvlaXQ-Bb_7-8n9w"
}
```

