### PR TITLE
Fix user phone field description

### DIFF
--- a/objects.json
+++ b/objects.json
@@ -10885,11 +10885,11 @@
             },
             "mobile_phone": {
               "type": "string",
-              "description": "Information whether current user can see"
+              "description": "User's mobile phone number"
             },
             "home_phone": {
               "type": "string",
-              "description": "User's mobile phone number"
+              "description": "User's additional phone number"
             },
             "site": {
               "type": "string",


### PR DESCRIPTION
[objects/user](https://vk.com/dev/objects/user)

> - mobile_phone (string) — user's mobile phone number (only for standalone applications);
> - home_phone (string) — user's additional phone number.